### PR TITLE
voice-map: improve Recovery/Murder player line matches

### DIFF
--- a/CompanionAstra_LockedIDs/Program.cs
+++ b/CompanionAstra_LockedIDs/Program.cs
@@ -1939,9 +1939,9 @@ namespace CompanionClaude
                 // === HATRED SCENE PLAYER VOICE (text-first, closest vanilla) ===
                 (0x0EEC8B, hat1_P.Responses[0].FormKey),  // "Are you threatening me?"
                 // === RECOVERY SCENE PLAYER VOICE (text-first, closest vanilla) ===
-                (0x02672C, rec1_P.Responses[0].FormKey),  // "Sounds good."
+                (0x218C1B, rec1_P.Responses[0].FormKey),  // "I'm glad we're good again."
                 // === MURDER WARNING SCENE PLAYER VOICE (text-first, closest vanilla) ===
-                (0x0E576F, mur1_P.Responses[0].FormKey),  // "You'll have to explain what's going on."
+                (0x100280, mur1_P.Responses[0].FormKey),  // "This is all my fault. Will you forgive me?"
             };
 
             foreach (var voiceType in new[] { "PlayerVoiceMale01", "PlayerVoiceFemale01" }) {

--- a/docs/RECOVERY_MURDER_LOCKED_IDS.md
+++ b/docs/RECOVERY_MURDER_LOCKED_IDS.md
@@ -16,8 +16,10 @@ These IDs are fixed in `CompanionAstra_LockedIDs/Program.cs` and must not change
 ## Player Voice Mapping (Vanilla Player Lines)
 FormKey is the Fallout4.esm INFO used for audio. Text is the source of truth.
 
-- 00F700 -> 0002672C "Sounds good."
-- 00F720 -> 000E576F "You'll have to explain what's going on."
+- 00F700 -> 00218C1B "I'm glad we're good again."
+  - Previous: 0002672C "Sounds good." (too generic for reconciliation context)
+- 00F720 -> 00100280 "This is all my fault. Will you forgive me?"
+  - Previous: 000E576F "You'll have to explain what's going on." (wrong direction — player was asking for explanation, not offering one)
 
 ## TTS Generation
 To generate Astra TTS for Recovery/Murder NPC lines, run:


### PR DESCRIPTION
## Summary
- **Recovery scene**: Changed player voice from "Sounds good." (0x02672C) to "I'm glad we're good again." (0x218C1B) — much better fit for a reconciliation scene where the player text is "We are back on track."
- **Murder scene**: Changed player voice from "You'll have to explain what's going on." (0x0E576F) to "This is all my fault. Will you forgive me?" (0x100280) — the old mapping had the player *asking* for an explanation when the dialogue text ("I can explain.") is the player *offering* one.
- Updated `docs/RECOVERY_MURDER_LOCKED_IDS.md` with new mappings and rationale for change.

Both vanilla INFO IDs verified to exist as `.fuz` files in `PlayerVoiceMale01` and `PlayerVoiceFemale01`. Locked dialogue INFO IDs (0x00F700, 0x00F720) are unchanged.

Fixes #5

## Test plan
- [ ] Build ESP with `dotnet run` — verify no errors
- [ ] In CK: preview Recovery scene, confirm player audio plays "I'm glad we're good again."
- [ ] In CK: preview Murder scene, confirm player audio plays "This is all my fault. Will you forgive me?"
- [ ] In-game: trigger Recovery and Murder scenes, verify voice matches context

🤖 Generated with [Claude Code](https://claude.com/claude-code)