### PR TITLE
feat: add trade functionality to pickup scene

### DIFF
--- a/CompanionAstra_LockedIDs/Program.cs
+++ b/CompanionAstra_LockedIDs/Program.cs
@@ -1076,6 +1076,8 @@ namespace CompanionClaude
             // We are replacing Player Positive first (left-to-right), keeping structure intact.
             var astraPickup_PPos = CreateSceneTopic("COMAstraPickup_PPos", "Let's go", "Sure, let's go.");
             var astraPickup_PNeg = CreateSceneTopic("COMAstraPickup_PNeg", "Never mind", "You know what. Never mind.");
+            var astraPickup_PNeu = CreateSceneTopic("COMAstraPickup_PNeu", "Trade", "Let's trade.");
+            astraPickup_PNeu.Responses[0].SharedDialog.SetTo(new FormKey(fo4, 0x162C82));
 
             // Link directly to Piper's vanilla topics to mirror CK layout exactly.
             var piperPickup_PPos = new FormLink<IDialogTopicGetter>(new FormKey(fo4, 0x162C4F));
@@ -1104,7 +1106,7 @@ namespace CompanionClaude
             pickupAction1.NpcPositiveResponse.SetTo(piperPickup_NPos);
             pickupAction1.PlayerNegativeResponse.SetTo(astraPickup_PNeg);
             pickupAction1.NpcNegativeResponse.SetTo(piperPickup_NNeg);
-            pickupAction1.PlayerNeutralResponse.SetTo(piperPickup_PNeu);
+            pickupAction1.PlayerNeutralResponse.SetTo(astraPickup_PNeu);
             pickupAction1.NpcNeutralResponse.SetTo(piperPickup_NNeu);
             pickupAction1.PlayerQuestionResponse.SetTo(piperPickup_PQue);
             pickupAction1.NpcQuestionResponse.SetTo(piperPickup_NQue);


### PR DESCRIPTION
## Summary
- Adds "Let's trade." player dialogue option to the pickup scene
- Links to vanilla trade SharedDialog (`0x162C82` from Fallout4.esm)
- Replaces the Piper neutral response with a custom Astra trade topic
- No locked INFO IDs changed

Generated by Gemini CLI (Flash), committed by Claude Code on Gemini's behalf (AttachConsole errors prevented git operations in headless mode).

Fixes #8

## Changes
```csharp
var astraPickup_PNeu = CreateSceneTopic("COMAstraPickup_PNeu", "Trade", "Let's trade.");
astraPickup_PNeu.Responses[0].SharedDialog.SetTo(new FormKey(fo4, 0x162C82));
// pickupAction1.PlayerNeutralResponse now points to astraPickup_PNeu
```

## Test plan
- [ ] Build ESP with `dotnet run` — verify no errors
- [ ] In CK: open pickup scene, verify "Let's trade." appears as neutral option
- [ ] In-game: recruit Astra, select "Let's trade.", verify barter menu opens

🤖 Generated with [Gemini CLI](https://github.com/google-gemini/gemini-cli) + [Claude Code](https://claude.com/claude-code)