### PR TITLE
Add automated test loop: Papyrus log collector + PC watcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 bin/
 obj/
 out/
+
+# Full unfiltered Papyrus logs (filtered Astra logs ARE committed)
+logs/raw/
 *.user
 *.suo
 .vs/

--- a/logs/README.md
+++ b/logs/README.md
@@ -1,0 +1,42 @@
+# Papyrus Test Logs
+
+This folder bridges in-game testing (on the PC) and Claude cloud sessions
+(which can only see what's pushed to GitHub).
+
+Every quest stage in the mod writes a `Debug.Trace` line tagged `MQAstraALT`
+to the Papyrus log. Collecting that log after a test session lets Claude see
+exactly which stages fired, in what order, and what failed -- no need to
+recall it from memory.
+
+## Workflow (on the gaming PC)
+
+1. Play a test session in Fallout 4.
+2. Quit the game.
+3. Double-click `logs\collect_log.bat` in your local copy of this repo.
+
+That's it. The script:
+
+- Enables Papyrus logging in `Fallout4Custom.ini` if it isn't already
+  (first run only -- restart the game once after this, then re-test)
+- Copies the full `Papyrus.0.log` to `logs/raw/` (kept locally, not committed)
+- Filters the Astra-related lines into `logs/astra_<timestamp>.log` and
+  `logs/latest_astra.log`
+- Commits and pushes to GitHub
+
+Then tell Claude the log is up. It reads `logs/latest_astra.log`.
+
+## Important timing note
+
+Fallout 4 rotates its logs on every launch (`Papyrus.0.log` becomes
+`Papyrus.1.log`). Run the collector **after quitting and before launching
+the game again**, or the session you wanted is no longer log 0.
+
+## Files
+
+| File | What it is | Committed? |
+| --- | --- | --- |
+| `collect_log.bat` | Double-click entry point (collect + push) | yes |
+| `collect_papyrus_log.ps1` | The actual script; `-Push` commits/pushes | yes |
+| `astra_<timestamp>.log` | Astra-only lines from one test session | yes |
+| `latest_astra.log` | Copy of the most recent collection | yes |
+| `raw/Papyrus_*.log` | Full unfiltered log copies | no (local only) |

--- a/logs/README.md
+++ b/logs/README.md
@@ -8,7 +8,29 @@ to the Papyrus log. Collecting that log after a test session lets Claude see
 exactly which stages fired, in what order, and what failed -- no need to
 recall it from memory.
 
-## Workflow (on the gaming PC)
+## Fully automated workflow (recommended)
+
+Double-click `logs\start_watcher.bat` once and leave its window open
+(minimized is fine). While it runs:
+
+- **Game closed:** every 5 minutes it pulls new commits from GitHub. If
+  code changed, it rebuilds the ESP, compiles Papyrus, and deploys both
+  to the game's Data folder. It prints a warning if voice lines changed
+  (voice generation stays manual: `python generate_voices.py`).
+- **You quit Fallout 4:** it automatically collects the Papyrus log,
+  filters the Astra lines, and pushes them to GitHub.
+
+So the whole loop from the phone is: tell Claude what to change -> Claude
+pushes -> the PC rebuilds itself -> launch the game and test -> quit ->
+the log uploads itself -> tell Claude to read it. Nothing to type on
+the PC.
+
+Game/tool paths are set at the top of `astra_watcher.ps1` (currently the
+`E:\SteamLibrary` install from docs/BUILD_GUIDE.md); edit them there if
+the install moves. To make the watcher start with Windows, put a shortcut
+to `start_watcher.bat` in `shell:startup`.
+
+## Manual collection (fallback)
 
 1. Play a test session in Fallout 4.
 2. Quit the game.
@@ -35,7 +57,9 @@ the game again**, or the session you wanted is no longer log 0.
 
 | File | What it is | Committed? |
 | --- | --- | --- |
-| `collect_log.bat` | Double-click entry point (collect + push) | yes |
+| `start_watcher.bat` | Double-click once: auto pull/build/deploy + auto log upload | yes |
+| `astra_watcher.ps1` | The watcher loop (paths configured at the top) | yes |
+| `collect_log.bat` | Manual fallback: collect + push once | yes |
 | `collect_papyrus_log.ps1` | The actual script; `-Push` commits/pushes | yes |
 | `astra_<timestamp>.log` | Astra-only lines from one test session | yes |
 | `latest_astra.log` | Copy of the most recent collection | yes |

--- a/logs/astra_watcher.ps1
+++ b/logs/astra_watcher.ps1
@@ -1,0 +1,123 @@
+# Astra watcher: leave this running on the gaming PC and the test loop
+# becomes hands-off.
+#
+#   - While Fallout 4 is NOT running: every few minutes it pulls new
+#     commits from GitHub. If code changed, it rebuilds the ESP, compiles
+#     Papyrus, and deploys both to the game's Data folder.
+#   - When you quit Fallout 4: it automatically collects the Papyrus log
+#     and pushes the Astra-filtered lines to GitHub for Claude to read.
+#
+# Start it with start_watcher.bat and leave the window open.
+
+param(
+    [switch]$NoBuild   # pull + collect logs only, never build/deploy
+)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path -Parent $PSScriptRoot
+
+# --- Paths (from docs/BUILD_GUIDE.md; edit here if your install moves) ------
+$gameDir   = 'E:\SteamLibrary\steamapps\common\Fallout 4'
+$dataDir   = Join-Path $gameDir 'Data'
+$compiler  = Join-Path $gameDir 'Papyrus Compiler\PapyrusCompiler.exe'
+$flagsFile = Join-Path $dataDir 'Scripts\Source\Base\Institute_Papyrus_Flags.flg'
+$vanillaSrc = (Join-Path $dataDir 'Scripts\Source\User') + ';' + (Join-Path $dataDir 'Scripts\Source\Base')
+
+$espName = 'MQAstraALT.esp'
+$pexRel  = 'Fragments\Quests\QF_MQAstraALT_0000080A.pex'
+
+$syncIntervalSec = 300   # check GitHub every 5 minutes while game is closed
+$pollSec         = 15
+
+function Get-GameRunning {
+    [bool](Get-Process -Name 'Fallout4' -ErrorAction SilentlyContinue)
+}
+
+# Pull from GitHub; returns list of changed files, or $null if up to date.
+function Sync-Repo {
+    git -C $repoRoot fetch --quiet 2>$null
+    $local  = (git -C $repoRoot rev-parse HEAD).Trim()
+    $remote = git -C $repoRoot rev-parse '@{u}' 2>$null
+    if (-not $remote) { return $null }
+    $remote = "$remote".Trim()
+    if ($local -eq $remote) { return $null }
+    git -C $repoRoot pull --rebase --quiet
+    return @(git -C $repoRoot diff --name-only $local $remote)
+}
+
+function Build-Mod {
+    Write-Host "[$(Get-Date -Format HH:mm)] Building ESP (dotnet run)..."
+    Push-Location $repoRoot
+    try {
+        dotnet run
+        if ($LASTEXITCODE) { throw "dotnet run failed (exit $LASTEXITCODE)" }
+
+        Write-Host "[$(Get-Date -Format HH:mm)] Compiling Papyrus..."
+        & $compiler (Join-Path $repoRoot 'Source') `
+            "-i=$(Join-Path $repoRoot 'Source');$vanillaSrc" `
+            "-o=$(Join-Path $repoRoot 'out')" `
+            "-f=$flagsFile" -all
+        if ($LASTEXITCODE) { throw "PapyrusCompiler failed (exit $LASTEXITCODE)" }
+
+        Copy-Item (Join-Path $repoRoot $espName) (Join-Path $dataDir $espName) -Force
+        $pexDstDir = Join-Path $dataDir ('Scripts\' + (Split-Path -Parent $pexRel))
+        New-Item -ItemType Directory -Force -Path $pexDstDir | Out-Null
+        Copy-Item (Join-Path $repoRoot "out\$pexRel") (Join-Path $dataDir "Scripts\$pexRel") -Force
+
+        Write-Host "[$(Get-Date -Format HH:mm)] Deployed $espName + PEX to Data. Ready to test."
+        Write-Host "  (Remember: ESP changes need a New Game to take effect.)"
+    } finally {
+        Pop-Location
+    }
+}
+
+Write-Host "=== Astra watcher running ==="
+Write-Host "Repo: $repoRoot (branch: $((git -C $repoRoot rev-parse --abbrev-ref HEAD).Trim()))"
+Write-Host "Leave this window open. Play Fallout 4 normally; logs upload when you quit."
+Write-Host ""
+
+$lastSync   = [datetime]::MinValue
+$wasRunning = Get-GameRunning
+
+while ($true) {
+    $running = Get-GameRunning
+
+    # Game just exited -> collect and push the Papyrus log
+    if ($wasRunning -and -not $running) {
+        Write-Host "[$(Get-Date -Format HH:mm)] Fallout 4 exited; collecting Papyrus log..."
+        Start-Sleep -Seconds 5
+        try {
+            & (Join-Path $PSScriptRoot 'collect_papyrus_log.ps1') -Push
+        } catch {
+            Write-Host "Log collection failed: $_"
+        }
+    }
+    if (-not $wasRunning -and $running) {
+        Write-Host "[$(Get-Date -Format HH:mm)] Fallout 4 started. Have a good test session."
+    }
+
+    # While the game is closed, periodically pull (and build) new work
+    if (-not $running -and ((Get-Date) - $lastSync).TotalSeconds -ge $syncIntervalSec) {
+        $lastSync = Get-Date
+        try {
+            $changed = Sync-Repo
+            if ($changed) {
+                Write-Host "[$(Get-Date -Format HH:mm)] Pulled updates from GitHub:"
+                $changed | ForEach-Object { Write-Host "    $_" }
+
+                $needsBuild = $changed | Where-Object { $_ -match '\.(cs|csproj|psc)$' -or $_ -eq 'stable_formkeys.json' }
+                if ($needsBuild -and -not $NoBuild) { Build-Mod }
+
+                if ($changed | Where-Object { $_ -match 'voice_lines\.json|generate_.*voices\.py' }) {
+                    Write-Host "  *** VOICE LINES CHANGED -- run 'python generate_voices.py' before testing. ***"
+                }
+            }
+        } catch {
+            Write-Host "[$(Get-Date -Format HH:mm)] Sync/build problem: $_"
+            Write-Host "  Watcher keeps running; will retry in $([int]($syncIntervalSec/60)) minutes."
+        }
+    }
+
+    $wasRunning = $running
+    Start-Sleep -Seconds $pollSec
+}

--- a/logs/collect_log.bat
+++ b/logs/collect_log.bat
@@ -1,0 +1,6 @@
+@echo off
+rem Double-click this after quitting Fallout 4 to collect the Papyrus log,
+rem filter the Astra lines, and push them to GitHub for Claude to read.
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0collect_papyrus_log.ps1" -Push
+echo.
+pause

--- a/logs/collect_papyrus_log.ps1
+++ b/logs/collect_papyrus_log.ps1
@@ -84,6 +84,7 @@ if ($Push) {
     try {
         git add logs
         git commit -m "Add Papyrus test log $stamp"
+        git pull --rebase --quiet
         git push
         Write-Host ""
         Write-Host "Pushed to GitHub. Tell Claude the log is up and it can read logs/latest_astra.log."

--- a/logs/collect_papyrus_log.ps1
+++ b/logs/collect_papyrus_log.ps1
@@ -1,0 +1,99 @@
+# Collects the Fallout 4 Papyrus log after a test session, filters the
+# Astra-related lines into logs/, and (with -Push) commits and pushes them
+# so a Claude cloud session can read the results.
+#
+# Run this AFTER quitting Fallout 4 and BEFORE launching it again --
+# the game rotates Papyrus.0.log -> Papyrus.1.log on every launch.
+
+param(
+    [switch]$Push
+)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$logsDir  = Join-Path $repoRoot 'logs'
+$rawDir   = Join-Path $logsDir 'raw'
+New-Item -ItemType Directory -Force -Path $rawDir | Out-Null
+
+$docs = [Environment]::GetFolderPath('MyDocuments')
+
+# --- 1. Make sure Papyrus logging is enabled in Fallout4Custom.ini ---------
+$iniPath = Join-Path $docs 'My Games\Fallout4\Fallout4Custom.ini'
+$managedKeys = 'bEnableLogging', 'bEnableTrace', 'bLoadDebugInformation'
+
+if (-not (Test-Path $iniPath)) {
+    New-Item -ItemType File -Force -Path $iniPath | Out-Null
+}
+$iniRaw = Get-Content $iniPath -Raw -ErrorAction SilentlyContinue
+if ($null -eq $iniRaw) { $iniRaw = '' }
+
+$needsUpdate = $false
+foreach ($k in $managedKeys) {
+    if ($iniRaw -notmatch "(?m)^\s*$k\s*=\s*1\s*$") { $needsUpdate = $true }
+}
+
+if ($needsUpdate) {
+    Copy-Item $iniPath "$iniPath.bak" -Force
+    # Drop any existing values for the keys we manage, then append a
+    # [Papyrus] block at the end (last value wins in Bethesda INIs).
+    $lines = @(Get-Content $iniPath | Where-Object {
+        $_ -notmatch '^\s*(bEnableLogging|bEnableTrace|bLoadDebugInformation)\s*='
+    })
+    $lines += '', '[Papyrus]'
+    foreach ($k in $managedKeys) { $lines += "$k=1" }
+    Set-Content -Path $iniPath -Value $lines
+    Write-Host "Enabled Papyrus logging in Fallout4Custom.ini (backup saved as Fallout4Custom.ini.bak)."
+    Write-Host "If Fallout 4 is running, restart it -- logging takes effect on next launch."
+}
+
+# --- 2. Grab the current Papyrus log ---------------------------------------
+$logPath = Join-Path $docs 'My Games\Fallout4\Logs\Script\Papyrus.0.log'
+if (-not (Test-Path $logPath)) {
+    Write-Host "No Papyrus log found at:"
+    Write-Host "  $logPath"
+    Write-Host "Logging was just enabled (or the game hasn't run since). Play a test session, quit, and run this again."
+    exit 1
+}
+
+$stamp = Get-Date -Format 'yyyy-MM-dd_HHmm'
+$rawCopy = Join-Path $rawDir "Papyrus_$stamp.log"
+Copy-Item $logPath $rawCopy
+
+# --- 3. Filter the Astra-related lines into the repo ------------------------
+$rawLines = Get-Content $logPath
+$astraLines = @($rawLines | Where-Object { $_ -match 'MQAstraALT|COMAstra|Astra' })
+
+$outFile = Join-Path $logsDir "astra_$stamp.log"
+$header = @(
+    "# Astra-filtered Papyrus log",
+    "# Collected: $stamp",
+    "# Source: $logPath",
+    "# Raw log lines: $($rawLines.Count) | Astra lines: $($astraLines.Count)",
+    "# Full unfiltered copy kept locally at logs/raw/ (not committed)",
+    ""
+)
+$header + $astraLines | Set-Content $outFile
+Copy-Item $outFile (Join-Path $logsDir 'latest_astra.log') -Force
+
+Write-Host ""
+Write-Host "Collected $($astraLines.Count) Astra lines -> logs\astra_$stamp.log"
+
+# --- 4. Optionally commit and push so Claude can read it --------------------
+if ($Push) {
+    Push-Location $repoRoot
+    try {
+        git add logs
+        git commit -m "Add Papyrus test log $stamp"
+        git push
+        Write-Host ""
+        Write-Host "Pushed to GitHub. Tell Claude the log is up and it can read logs/latest_astra.log."
+    } catch {
+        Write-Host ""
+        Write-Host "Log collected, but git commit/push failed: $_"
+        Write-Host "You can push manually with: git add logs && git commit -m 'test log' && git push"
+    } finally {
+        Pop-Location
+    }
+} else {
+    Write-Host "Run with -Push (or use collect_log.bat) to commit and push it to GitHub for Claude."
+}

--- a/logs/start_watcher.bat
+++ b/logs/start_watcher.bat
@@ -1,0 +1,7 @@
+@echo off
+title Astra Watcher
+rem Double-click once and leave the window open. It pulls Claude's changes,
+rem rebuilds/deploys the mod while the game is closed, and uploads the
+rem Papyrus log automatically whenever you quit Fallout 4.
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0astra_watcher.ps1"
+pause


### PR DESCRIPTION
Automates the play-test feedback loop between the gaming PC and Claude cloud sessions, so testing works hands-free from the phone.

## What's included

**`logs/start_watcher.bat` + `logs/astra_watcher.ps1`** — leave running on the gaming PC:
- While Fallout 4 is closed: pulls new commits from GitHub every 5 minutes; when code changed, rebuilds the ESP (`dotnet run`), compiles Papyrus, and deploys both to the game's Data folder. Prints a warning when voice lines changed (voice generation stays manual).
- When Fallout 4 exits: automatically collects the Papyrus log and pushes the Astra-filtered lines to GitHub.

**`logs/collect_log.bat` + `logs/collect_papyrus_log.ps1`** — manual fallback for one-off collection:
- Enables Papyrus logging in `Fallout4Custom.ini` on first run (with backup)
- Copies the full `Papyrus.0.log` locally (gitignored) and commits only the `MQAstraALT`/Astra-filtered lines as `logs/astra_<timestamp>.log` and `logs/latest_astra.log`
- Rebases before pushing to avoid colliding with commits made mid-playtest

**`logs/README.md`** — workflow documentation, including the log-rotation timing rule (collect after quitting, before relaunching).

**`.gitignore`** — ignores `logs/raw/` (full unfiltered logs stay local).

## Why

Quest stages already emit `Debug.Trace` lines tagged `MQAstraALT`; this makes those logs readable from cloud sessions instead of relying on memory of the test session. Build paths (E:\SteamLibrary install) are configured at the top of `astra_watcher.ps1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pd64aBDLTtBmHAQzcfcs2K

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pd64aBDLTtBmHAQzcfcs2K)_